### PR TITLE
More nginx controls, add attribute client_max_body_size

### DIFF
--- a/controls/nginx_spec.rb
+++ b/controls/nginx_spec.rb
@@ -181,3 +181,64 @@ control 'nginx-10' do
     its('add_header') { should include 'X-Content-Type-Options nosniff' }
   end
 end
+
+control 'nginx-11' do
+  impact 1.0
+  title 'Disable content-type sniffing'
+  desc 'It prevents browser from trying to mime-sniff the content-type of a response away from the one being declared by the server. It reduces exposure to drive-by downloads and the risks of user uploaded content that, with clever naming, could be treated as a different content-type, like an executable.'
+  describe parse_config_file(nginx_hardening, options_add_header) do
+    its('add_header') { should include 'X-Content-Type-Options nosniff' }
+  end
+end
+
+control 'nginx-12' do
+  impact 1.0
+  title 'TLS Protocols'
+  desc 'When choosing a cipher during an SSLv3 or TLSv1 handshake, normally the client\'s preference is used. If this directive is enabled, the server\'s preference will be used instead.'
+  ref 'SSL Hardening config', url: 'https://mozilla.github.io/server-side-tls/ssl-config-generator/'
+  describe file(nginx_conf) do
+    its('content') { should match /^\s+ssl_protocols TLSv1.2;$/ }
+    its('content') { should match /^\s+ssl_session_tickets off;$/ }
+    its('content') { should match /^\s+ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';$/ }
+    its('content') { should match /^\s+ssl_prefer_server_ciphers on;$/ }
+    its('content') { should match /^\s+ssl_dhparam \/etc\/nginx\/ssl\/dhparam.pem;$/ }
+    its('content') { should match /^\s+ssl on;$/ }
+  end
+end
+
+control 'nginx-13' do
+  impact 1.0
+  title 'Add HSTS Header'
+  desc 'HTTP Strict Transport Security (HSTS) is a web security policy mechanism which helps to protect websites against protocol downgrade attacks and cookie hijacking. It allows web servers to declare that web browsers (or other complying user agents) should only interact with it using secure HTTPS connections, and never via the insecure HTTP protocol. HSTS is an IETF standards track protocol and is specified in RFC 6797.'
+  describe file(nginx_conf) do
+    its('content') { should match /^\s+add_header Strict-Transport-Security max-age=15768000;$/ }
+  end
+end
+
+control 'nginx-14' do
+  impact 1.0
+  title 'Disable insecure HTTP-methods'
+  desc 'Disable insecure HTTP-methods and allow only necessary methods.'
+
+  describe file(nginx_conf) do
+    its('content') { should match /^\s+if ($request_method !~ ^(GET|HEAD|POST)$ )$/ }
+  end
+end
+
+control 'nginx-15' do
+  impact 1.0
+  title 'Disable content-type sniffing'
+  desc 'It prevents browser from trying to mime-sniff the content-type of a response away from the one being declared by the server. It reduces exposure to drive-by downloads and the risks of user uploaded content that, with clever naming, could be treated as a different content-type, like an executable.'
+  describe parse_config_file(nginx_hardening, options_add_header) do
+    its('content') { should match /^\s+add_header Header set Content-Security-Policy "script-src 'self'; object-src 'self'";$/ }
+  end
+end
+
+control 'nginx-16' do
+  impact 1.0
+  title 'Set cookie with HttpOnly and Secure flag'
+  desc 'You can mitigate most of the common Cross Site Scripting attack using HttpOnly and Secure flag in a cookie. Without having HttpOnly and Secure, it is possible to steal or manipulate web application session and cookies and it’s dangerous.'
+  describe parse_config_file(nginx_hardening, options_add_header) do
+    its('content') { should match /^\s+set_cookie_flag * HttpOnly secure;$/ }
+  end
+end

--- a/controls/nginx_spec.rb
+++ b/controls/nginx_spec.rb
@@ -23,7 +23,13 @@ title 'NGINX server config'
 # attributes
 CLIENT_MAX_BODY_SIZE = attribute(
   'client_max_body_size',
-  description: ' Sets the maximum allowed size of the client request body, specified in the “Content-Length” request header field. If the size in a request exceeds the configured value, the 413 (Request Entity Too Large) error is returned to the client. Please be aware that browsers cannot correctly display this error. Setting size to 0 disables checking of client request body size. ',
+  description: ' Sets the maximum allowed size of the client request body, specified in the “Content-Length” request header field. If the size in a request exceeds the configured value, the 413 (Request Entity Too Large) error is returned to the client. Please be aware that browsers cannot correctly display this error. Setting size to 0 disables checking of client request body size.',
+  default: '1k'
+)
+
+CLIENT_BODY_BUFFER_SIZE = attribute(
+  'client_body_buffer_size',
+  description: ' Sets buffer size for reading client request body. In case the request body is larger than the buffer, the whole body or only its part is written to a temporary file. By default, buffer size is equal to two memory pages. This is 8K on x86, other 32-bit platforms, and x86-64. It is usually 16K on other 64-bit platforms.',
   default: '1k'
 )
 
@@ -119,10 +125,10 @@ control 'nginx-06' do
   title 'Prevent buffer overflow attacks'
   desc 'Buffer overflow attacks are made possible by writing data to a buffer and exceeding that buffer boundary and overwriting memory fragments of a process. To prevent this in nginx we can set buffer size limitations for all clients.'
   describe parse_config_file(nginx_conf, options) do
-    its('client_body_buffer_size') { should eq CLIENT_MAX_BODY_SIZE }
+    its('client_body_buffer_size') { should eq CLIENT_BODY_BUFFER_SIZE }
   end
   describe parse_config_file(nginx_conf, options) do
-    its('client_max_body_size') { should eq '1k' }
+    its('client_max_body_size') { should eq CLIENT_MAX_BODY_SIZE }
   end
   describe parse_config_file(nginx_hardening, options) do
     its('client_header_buffer_size') { should eq '1k' }

--- a/controls/nginx_spec.rb
+++ b/controls/nginx_spec.rb
@@ -39,6 +39,42 @@ CLIENT_HEADER_BUFFER_SIZE = attribute(
   default: '1k'
 )
 
+LARGE_CLIENT_HEADER_BUFFER = attribute(
+  'large_client_header_buffers',
+  description: 'Sets the maximum number and size of buffers used for reading large client request header. A request line cannot exceed the size of one buffer, or the 414 (Request-URI Too Large) error is returned to the client. A request header field cannot exceed the size of one buffer as well, or the 400 (Bad Request) error is returned to the client. Buffers are allocated only on demand. By default, the buffer size is equal to 8K bytes. If after the end of request processing a connection is transitioned into the keep-alive state, these buffers are released.',
+  default: '2 1k'
+)
+
+KEEPALIVE_TIMEOUT = attribute(
+  'keepalive_timeout',
+  description: 'The first parameter sets a timeout during which a keep-alive client connection will stay open on the server side. The zero value disables keep-alive client connections. The optional second parameter sets a value in the “Keep-Alive: timeout=time” response header field. Two parameters may differ.',
+  default: '5 5'
+)
+
+CLIENT_BODY_TIMEOUT = attribute(
+  'client_body_timeout',
+  description: 'Defines a timeout for reading client request body. The timeout is set only for a period between two successive read operations, not for the transmission of the whole request body. If a client does not transmit anything within this time, the 408 (Request Time-out) error is returned to the client.',
+  default: '10'
+)
+
+CLIENT_HEADER_TIMEOUT = attribute(
+  'client_header_timeout',
+  description: 'Defines a timeout for reading client request header. If a client does not transmit the entire header within this time, the 408 (Request Time-out) error is returned to the client.',
+  default: '10'
+)
+
+SEND_TIMEOUT = attribute(
+  'send_timeout',
+  description: 'Sets a timeout for transmitting a response to the client. The timeout is set only between two successive write operations, not for the transmission of the whole response. If the client does not receive anything within this time, the connection is closed.',
+  default: '10'
+)
+
+HTTP_METHODS = attribute(
+  'http_methods',
+  description: 'Specify the used HTTP methods',
+  default: 'GET\|HEAD\|POST'
+)
+
 only_if do
   command('nginx').exist?
 end
@@ -140,7 +176,7 @@ control 'nginx-06' do
     its('client_header_buffer_size') { should eq CLIENT_HEADER_BUFFER_SIZE }
   end
   describe parse_config_file(nginx_hardening, options) do
-    its('large_client_header_buffers') { should eq '2 1k' }
+    its('large_client_header_buffers') { should eq LARGE_CLIENT_HEADER_BUFFER }
   end
 end
 
@@ -149,16 +185,16 @@ control 'nginx-07' do
   title 'Control timeouts to improve performance'
   desc 'Control timeouts to improve server performance and cut clients.'
   describe parse_config_file(nginx_conf, options) do
-    its('keepalive_timeout') { should eq '5 5' }
+    its('keepalive_timeout') { should eq KEEPALIVE_TIMEOUT }
   end
   describe parse_config_file(nginx_hardening, options) do
-    its('client_body_timeout') { should eq '10' }
+    its('client_body_timeout') { should eq CLIENT_BODY_TIMEOUT }
   end
   describe parse_config_file(nginx_hardening, options) do
-    its('client_header_timeout') { should eq '10' }
+    its('client_header_timeout') { should eq CLIENT_HEADER_TIMEOUT }
   end
   describe parse_config_file(nginx_hardening, options) do
-    its('send_timeout') { should eq '10' }
+    its('send_timeout') { should eq SEND_TIMEOUT }
   end
 end
 

--- a/controls/nginx_spec.rb
+++ b/controls/nginx_spec.rb
@@ -274,9 +274,10 @@ control 'nginx-14' do
   impact 1.0
   title 'Disable insecure HTTP-methods'
   desc 'Disable insecure HTTP-methods and allow only necessary methods.'
+  ref 'OWASP HTTP Methods', url: 'https://www.owasp.org/index.php/Test_HTTP_Methods_(OTG-CONFIG-006)'
 
   describe file(nginx_conf) do
-    its('content') { should match(/^\s+if ($request_method !~ ^(GET|HEAD|POST)$ )$/) }
+    its('content') { should match(/^\s*if\s+\(\$request_method\s+\!\~\s+\^\(#{HTTP_METHODS}\)\$\)\{?$/) }
   end
 end
 

--- a/controls/nginx_spec.rb
+++ b/controls/nginx_spec.rb
@@ -23,13 +23,19 @@ title 'NGINX server config'
 # attributes
 CLIENT_MAX_BODY_SIZE = attribute(
   'client_max_body_size',
-  description: ' Sets the maximum allowed size of the client request body, specified in the “Content-Length” request header field. If the size in a request exceeds the configured value, the 413 (Request Entity Too Large) error is returned to the client. Please be aware that browsers cannot correctly display this error. Setting size to 0 disables checking of client request body size.',
+  description: 'Sets the maximum allowed size of the client request body, specified in the “Content-Length” request header field. If the size in a request exceeds the configured value, the 413 (Request Entity Too Large) error is returned to the client. Please be aware that browsers cannot correctly display this error. Setting size to 0 disables checking of client request body size.',
   default: '1k'
 )
 
 CLIENT_BODY_BUFFER_SIZE = attribute(
   'client_body_buffer_size',
-  description: ' Sets buffer size for reading client request body. In case the request body is larger than the buffer, the whole body or only its part is written to a temporary file. By default, buffer size is equal to two memory pages. This is 8K on x86, other 32-bit platforms, and x86-64. It is usually 16K on other 64-bit platforms.',
+  description: 'Sets buffer size for reading client request body. In case the request body is larger than the buffer, the whole body or only its part is written to a temporary file. By default, buffer size is equal to two memory pages. This is 8K on x86, other 32-bit platforms, and x86-64. It is usually 16K on other 64-bit platforms.',
+  default: '1k'
+)
+
+CLIENT_HEADER_BUFFER_SIZE = attribute(
+  'client_header_buffer_size',
+  description: 'Sets buffer size for reading client request header. For most requests, a buffer of 1K bytes is enough. However, if a request includes long cookies, or comes from a WAP client, it may not fit into 1K. If a request line or a request header field does not fit into this buffer then larger buffers, configured by the large_client_header_buffers directive, are allocated.',
   default: '1k'
 )
 
@@ -131,7 +137,7 @@ control 'nginx-06' do
     its('client_max_body_size') { should eq CLIENT_MAX_BODY_SIZE }
   end
   describe parse_config_file(nginx_hardening, options) do
-    its('client_header_buffer_size') { should eq '1k' }
+    its('client_header_buffer_size') { should eq CLIENT_HEADER_BUFFER_SIZE }
   end
   describe parse_config_file(nginx_hardening, options) do
     its('large_client_header_buffers') { should eq '2 1k' }

--- a/controls/nginx_spec.rb
+++ b/controls/nginx_spec.rb
@@ -234,8 +234,8 @@ end
 
 control 'nginx-15' do
   impact 1.0
-  title 'Disable content-type sniffing'
-  desc 'It prevents browser from trying to mime-sniff the content-type of a response away from the one being declared by the server. It reduces exposure to drive-by downloads and the risks of user uploaded content that, with clever naming, could be treated as a different content-type, like an executable.'
+  title 'Content-Security-Policy'
+  desc 'The Content-Security-Policy HTTP response header helps you reduce XSS risks on modern browsers by declaring what dynamic resources are allowed to load via a HTTP Header'
   describe parse_config_file(nginx_hardening, options_add_header) do
     its('content') { should match(/^\s*add_header Content-Security-Policy "script-src 'self'; object-src 'self'";$/) }
   end


### PR DESCRIPTION
- added attribute CLIENT_MAX_BODY_SIZE to solve #13 
- added control for Disable content-type sniffing, TLS Protocols configuration, HSTS Header, Disable insecure HTTP-methods, Content-Security-Policy, Set cookie with HttpOnly and Secure flag
