### PR TITLE
Increment version to correct tag

### DIFF
--- a/inspec.yml
+++ b/inspec.yml
@@ -5,6 +5,6 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Test-suite for best-practice nginx hardening
-version: 2.2.0
+version: 2.2.1
 supports:
   - os-family: unix


### PR DESCRIPTION
The 2.2.0 tag points to `inspec.yml` with version 2.1.0

This commit just bumps the version number so we can have a tag and version match.

Signed-off-by: James Stocks <jstocks@chef.io>