### PR TITLE
use parse_config instead of parse_config_file

### DIFF
--- a/controls/nginx_spec.rb
+++ b/controls/nginx_spec.rb
@@ -80,12 +80,13 @@ only_if do
 end
 
 # determine all required paths
-nginx_path      = '/etc/nginx'
-nginx_conf      = File.join(nginx_path, 'nginx.conf')
-nginx_confd     = File.join(nginx_path, 'conf.d')
-nginx_enabled   = File.join(nginx_path, 'sites-enabled')
-nginx_hardening = File.join(nginx_confd, '90.hardening.conf')
-conf_paths      = [nginx_conf, nginx_hardening]
+nginx_path          = '/etc/nginx'
+nginx_conf          = File.join(nginx_path, 'nginx.conf')
+nginx_confd         = File.join(nginx_path, 'conf.d')
+nginx_enabled       = File.join(nginx_path, 'sites-enabled')
+nginx_hardening     = File.join(nginx_confd, '90.hardening.conf')
+conf_paths          = [nginx_conf, nginx_hardening]
+nginx_parsed_config = command('nginx -T').stdout
 
 options = {
   assignment_regex: /^\s*([^:]*?)\s*\ \s*(.*?)\s*;$/
@@ -157,7 +158,7 @@ control 'nginx-05' do
   impact 1.0
   title 'Disable server_tokens directive'
   desc 'Disables emitting nginx version in error messages and in the “Server” response header field.'
-  describe parse_config_file(nginx_conf, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('server_tokens') { should eq 'off' }
   end
 end
@@ -166,16 +167,16 @@ control 'nginx-06' do
   impact 1.0
   title 'Prevent buffer overflow attacks'
   desc 'Buffer overflow attacks are made possible by writing data to a buffer and exceeding that buffer boundary and overwriting memory fragments of a process. To prevent this in nginx we can set buffer size limitations for all clients.'
-  describe parse_config_file(nginx_conf, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('client_body_buffer_size') { should eq CLIENT_BODY_BUFFER_SIZE }
   end
-  describe parse_config_file(nginx_conf, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('client_max_body_size') { should eq CLIENT_MAX_BODY_SIZE }
   end
-  describe parse_config_file(nginx_hardening, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('client_header_buffer_size') { should eq CLIENT_HEADER_BUFFER_SIZE }
   end
-  describe parse_config_file(nginx_hardening, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('large_client_header_buffers') { should eq LARGE_CLIENT_HEADER_BUFFER }
   end
 end
@@ -184,10 +185,10 @@ control 'nginx-07' do
   impact 1.0
   title 'Control simultaneous connections'
   desc 'NginxHttpLimitZone module to limit the number of simultaneous connections for the assigned session or as a special case, from one IP address.'
-  describe parse_config_file(nginx_hardening, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('limit_conn_zone') { should eq '$binary_remote_addr zone=default:10m' }
   end
-  describe parse_config_file(nginx_hardening, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('limit_conn') { should eq 'default 5' }
   end
 end
@@ -196,7 +197,7 @@ control 'nginx-08' do
   impact 1.0
   title 'Prevent clickjacking'
   desc 'Do not allow the browser to render the page inside an frame or iframe.'
-  describe parse_config_file(nginx_hardening, options_add_header) do
+  describe parse_config(nginx_parsed_config, options_add_header) do
     its('add_header') { should include 'X-Frame-Options SAMEORIGIN' }
   end
 end
@@ -205,7 +206,7 @@ control 'nginx-09' do
   impact 1.0
   title 'Enable Cross-site scripting filter'
   desc 'This header is used to configure the built in reflective XSS protection. This tells the browser to block the response if it detects an attack rather than sanitising the script.'
-  describe parse_config_file(nginx_hardening, options_add_header) do
+  describe parse_config(nginx_parsed_config, options_add_header) do
     its('add_header') { should include 'X-XSS-Protection "1; mode=block"' }
   end
 end
@@ -214,7 +215,7 @@ control 'nginx-10' do
   impact 1.0
   title 'Disable content-type sniffing'
   desc 'It prevents browser from trying to mime-sniff the content-type of a response away from the one being declared by the server. It reduces exposure to drive-by downloads and the risks of user uploaded content that, with clever naming, could be treated as a different content-type, like an executable.'
-  describe parse_config_file(nginx_hardening, options_add_header) do
+  describe parse_config(nginx_parsed_config, options_add_header) do
     its('add_header') { should include 'X-Content-Type-Options nosniff' }
   end
 end
@@ -224,13 +225,12 @@ control 'nginx-12' do
   title 'TLS Protocols'
   desc 'When choosing a cipher during an SSLv3 or TLSv1 handshake, normally the client\'s preference is used. If this directive is enabled, the server\'s preference will be used instead.'
   ref 'SSL Hardening config', url: 'https://mozilla.github.io/server-side-tls/ssl-config-generator/'
-  describe file(nginx_hardening) do
-    its('content') { should match(/^\s*ssl_protocols TLSv1.2;$/) }
-    its('content') { should match(/^\s*ssl_session_tickets off;$/) }
-    its('content') { should match(/^\s*ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';$/) }
-    its('content') { should match(/^\s*ssl_prefer_server_ciphers on;$/) }
-    its('content') { should match(%r{^\s*ssl_dhparam /etc/nginx/dh2048.pem;$}) }
-    # its('content') { should match(/^\s*ssl on;$/) }
+  describe parse_config(nginx_parsed_config, options) do
+    its('ssl_protocols') { should eq 'TLSv1.2' }
+    its('ssl_session_tickets') { should eq 'off' }
+    its('ssl_ciphers') { should eq '\'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256\'' }
+    its('ssl_prefer_server_ciphers') { should eq 'on' }
+    its('ssl_dhparam') { should eq '/etc/nginx/dh2048.pem' }
   end
 end
 
@@ -238,8 +238,8 @@ control 'nginx-13' do
   impact 1.0
   title 'Add HSTS Header'
   desc 'HTTP Strict Transport Security (HSTS) is a web security policy mechanism which helps to protect websites against protocol downgrade attacks and cookie hijacking. It allows web servers to declare that web browsers (or other complying user agents) should only interact with it using secure HTTPS connections, and never via the insecure HTTP protocol. HSTS is an IETF standards track protocol and is specified in RFC 6797.'
-  describe file(nginx_hardening) do
-    its('content') { should match(/^\s*add_header Strict-Transport-Security max-age=15768000;$/) }
+  describe parse_config(nginx_parsed_config, options_add_header) do
+    its('add_header') { should include 'Strict-Transport-Security max-age=15768000' }
   end
 end
 
@@ -258,8 +258,8 @@ control 'nginx-15' do
   impact 1.0
   title 'Content-Security-Policy'
   desc 'The Content-Security-Policy HTTP response header helps you reduce XSS risks on modern browsers by declaring what dynamic resources are allowed to load via a HTTP Header'
-  describe parse_config_file(nginx_hardening, options_add_header) do
-    its('content') { should match(/^\s*add_header Content-Security-Policy "script-src 'self'; object-src 'self'";$/) }
+  describe parse_config(nginx_parsed_config, options_add_header) do
+    its('add_header') { should include 'Content-Security-Policy "script-src \'self\'; object-src \'self\'"' }
   end
 end
 
@@ -267,8 +267,8 @@ control 'nginx-16' do
   impact 1.0
   title 'Set cookie with HttpOnly and Secure flag'
   desc 'You can mitigate most of the common Cross Site Scripting attack using HttpOnly and Secure flag in a cookie. Without having HttpOnly and Secure, it is possible to steal or manipulate web application session and cookies and it’s dangerous.'
-  describe parse_config_file(nginx_hardening, options_add_header) do
-    its('content') { should match(/^\s*set_cookie_flag * HttpOnly secure;$/) }
+  describe parse_config(nginx_parsed_config, options_add_header) do
+    its('set_cookie_flag') { should include '* HttpOnly secure' }
   end
 end
 
@@ -276,16 +276,16 @@ control 'nginx-17' do
   impact 1.0
   title 'Control timeouts to improve performance'
   desc 'Control timeouts to improve server performance and cut clients.'
-  describe parse_config_file(nginx_conf, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('keepalive_timeout') { should eq KEEPALIVE_TIMEOUT }
   end
-  describe parse_config_file(nginx_hardening, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('client_body_timeout') { should eq CLIENT_BODY_TIMEOUT }
   end
-  describe parse_config_file(nginx_hardening, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('client_header_timeout') { should eq CLIENT_HEADER_TIMEOUT }
   end
-  describe parse_config_file(nginx_hardening, options) do
+  describe parse_config(nginx_parsed_config, options) do
     its('send_timeout') { should eq SEND_TIMEOUT }
   end
 end


### PR DESCRIPTION
This PR changes the way the nginx-configuration is read.

Before, the indivual config-files got read.
Now the parsed nginx-configuration is read.

This way it does not matter where in the configuration an option is set.

As a next step I think we could (in a separate PR) remove the checks for `nginx_hardening     = File.join(nginx_confd, '90.hardening.conf')` and more generally check if the files in `/etc/nginx/conf.d` are secured against access. What do you think?

CC @chris-rock @atomic111 