### PR TITLE
Bump version to 2.3.0 and switch to inspec 3 for check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 **/.tmp
 Gemfile.lock
 Berksfile.lock
+inspec.lock
 nbproject

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,9 +2,6 @@
 AllCops:
   Exclude:
   - vendor/**/*
-  - "*/puppet/Puppetfile"
-  - "*/puppet/.tmp/**/*"
-  TargetRubyVersion: 1.9
 Documentation:
   Enabled: false
 AlignParameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [2.3.0](https://github.com/dev-sec/nginx-baseline/tree/2.3.0) (2019-05-14)
+[Full Changelog](https://github.com/dev-sec/nginx-baseline/compare/2.2.0...2.3.0)
+
+**Merged pull requests:**
+
+- Templates [\#30](https://github.com/dev-sec/nginx-baseline/pull/30) ([rndmh3ro](https://github.com/rndmh3ro))
+- remove test for hardening.conf file [\#28](https://github.com/dev-sec/nginx-baseline/pull/28) ([rndmh3ro](https://github.com/rndmh3ro))
+- use parse\_config instead of parse\_config\_file [\#27](https://github.com/dev-sec/nginx-baseline/pull/27) ([rndmh3ro](https://github.com/rndmh3ro))
+- Make nginx-14 and nginx-16 disabled by default based on dev-sec/nginx-baseline\#21 [\#26](https://github.com/dev-sec/nginx-baseline/pull/26) ([woneill](https://github.com/woneill))
+
 ## [2.2.0](https://github.com/dev-sec/nginx-baseline/tree/2.2.0) (2018-06-26)
 [Full Changelog](https://github.com/dev-sec/nginx-baseline/compare/2.1.0...2.2.0)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'highline', '~> 1.6.0'
-gem 'inspec', '~> 1'
-gem 'rack', '1.6.4'
-gem 'rake'
-gem 'rubocop', '~> 0.46.0'
+gem 'highline', '~> 2.0.2'
+gem 'inspec', '~> 3'
+gem 'rack', '~> 2.0.7'
+gem 'rake', '~> 12.3.2'
+gem 'rubocop', '~> 0.68.1'
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.12.0'
+  gem 'github_changelog_generator', '~> 1.14.3'
+  gem 'pry-coolline', '~> 0.2.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 #!/usr/bin/env rake
-# encoding: utf-8
 
 require 'rake/testtask'
 require 'rubocop/rake_task'
@@ -20,23 +19,30 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec inspec check #{dir}")
+    require 'inspec'
+    puts "Checking profile with InSpec Version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with s`rake changelog to=1.2.0`
-begin
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+  begin
+    require 'yaml'
+    metadata = YAML.load_file('inspec.yml')
+    v = ENV['to'] || metadata['version']
+    puts " * Generating changelog for version #{v}"
+    require 'github_changelog_generator/task'
+    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+      config.future_release = v
+      config.user = 'dev-sec'
+      config.project = 'nginx-baseline'
+    end
+    Rake::Task[:changelog].execute
+  rescue LoadError
+    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
   end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end

--- a/controls/nginx_spec.rb
+++ b/controls/nginx_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-#
 # Copyright 2015, Patrick Muench
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,6 +5,6 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Test-suite for best-practice nginx hardening
-version: 2.2.0
+version: 2.3.0
 supports:
   - os-family: unix

--- a/libraries/nginx_lib.rb
+++ b/libraries/nginx_lib.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-#
 # Copyright 2016, Patrick Muench
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Switched to inspec check without CLI, this will allow checking the profile with inspec 4 without having to auto accept the license.

I updated the Rakefile to only load the changelog task when it is targetted.

I had to specify the repo user and project in the config of the changelog task, otherwise, I was getting this exception:

```
Octokit::InvalidRepository: "/" is invalid as a repository identifier. Use the user/repo (String) format
```