### PR TITLE
Declare control source as UTF-8 encoding.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Metrics/PerceivedComplexity:
   Max: 10
 Metrics/AbcSize:
   Max: 30
+# Some releases of InSpec have issues with character encoding unless the encoding is declared.
+Style/Encoding:
+  Enabled: false

--- a/controls/nginx_spec.rb
+++ b/controls/nginx_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 # Copyright 2015, Patrick Muench
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixes #33

There are a number of issues open and closed for encoding in InSpec profiles https://github.com/inspec/inspec/issues?utf8=%E2%9C%93&q=is%3Aissue+encoding

To work in all versions of InSpec currently supported, this profile should keep the `# encoding: UTF-8` declaration.

Signed-off-by: James Stocks <jstocks@chef.io>